### PR TITLE
Fixed : define scaleX & scaleY even if initial scale is 0

### DIFF
--- a/src/charm.js
+++ b/src/charm.js
@@ -91,7 +91,7 @@ class Charm {
     //Add `scaleX` and `scaleY` properties to Pixi sprites
     this._addScaleProperties = (sprite) => {
       if (this.renderer === "pixi") {
-        if (!sprite.scaleX && sprite.scale.x) {
+        if (!("scaleX" in sprite) && ("scale" in sprite) && ("x" in sprite.scale)) {
           Object.defineProperty(
             sprite,
             "scaleX", {
@@ -104,7 +104,7 @@ class Charm {
             }
           );
         }
-        if (!sprite.scaleY && sprite.scale.y) {
+        if (!("scaleY" in sprite) && ("scale" in sprite) && ("y" in sprite.scale)) {
           Object.defineProperty(
             sprite,
             "scaleY", {


### PR DESCRIPTION
Using ``sprite.scale.x`` is not a good way to check if this property exists since values of 0 will not pass the test. Therefore ``scaleX`` and ``scaleY`` will never be defined for sprites with initial scale of 0.
I fixed it by simply testing the existence of the property, not its value.